### PR TITLE
Simple R notebook clustering ROIs

### DIFF
--- a/R/IDR0021-ROI-Clustering.ipynb
+++ b/R/IDR0021-ROI-Clustering.ipynb
@@ -100,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {"scrolled": true},
    "outputs": [],
    "source": [
     "describeDataframe(dataset, annotationFileID)"
@@ -123,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {"scrolled": true},
    "outputs": [],
    "source": [
     "df <- loadDataframe(dataset, annotationFileID, columns=c(2, 6))\n",
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {"scrolled": true},
    "outputs": [],
    "source": [
     "fit <- kmeans(sqrt(df$Area), 2)\n",

--- a/R/IDR0021-ROI-Clustering.ipynb
+++ b/R/IDR0021-ROI-Clustering.ipynb
@@ -1,0 +1,293 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ROI clustering by size (area)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load the romero.gateway library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(romero.gateway)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Connect to server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "server <- OMEROServer(host = 'eel.openmicroscopy.org', username='username', password='password', port= 4064L)\n",
+    "server <- connect(server)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the search functionility:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "searchResult <- searchFor(server, Dataset, 'Name', 'CDK5RAP2-C')\n",
+    "dataset <- searchResult[[1]]\n",
+    "paste('Dataset:', dataset@dataobject$getName(), 'loaded.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get the annotations file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In particular the file Id is needed to load the OMERO HDF table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "annos <- getAnnotations(server, 'DatasetData', getOMEROID(dataset), nameFilter = 'Test_Table')\n",
+    "annotationFileID = as.integer(annos$FileID)\n",
+    "paste('Annotation file id:', annotationFileID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check that we can load the annotations as dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "describeDataframe(dataset, annotationFileID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load the table as R dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Only load the relevant data, i. e. columns 2 (Shape-id) and 6 (Area)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df <- loadDataframe(dataset, annotationFileID, columns=c(2, 6))\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Do some analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Perform kmeans clustering and add the information to the dataframe:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit <- kmeans(sqrt(df$Area), 2)\n",
+    "df <- data.frame(df, fit$cluster)\n",
+    "names(df)[[3]] <- 'Cluster'\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot(df$Area, ylab='Area')\n",
+    "text(df$Area, labels=df$Cluster, cex= 0.5, pos=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save the results back to OMERO"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate the plot again, but this time save as png file and then attach it to the dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmpfile <- \"/tmp/Cluster_Plot.png\"\n",
+    "png(tmpfile)\n",
+    "plot(df$Area, ylab='Area')\n",
+    "text(df$Area, labels=df$Cluster, cex= 0.5, pos=3)\n",
+    "dev.off()\n",
+    "invisible(attachFile(dataset, tmpfile))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(Note: Wrapped into invisible(...) statement to suppress unnecessary output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The R dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is also stored as OMERO HDF table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "invisible(attachDataframe(dataset, df, \"KMeans_Clusters\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively as CSV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmpfile <- \"/tmp/KMeans_Clusters.csv\"\n",
+    "write.csv(df, file = tmpfile)\n",
+    "invisible(attachFile(dataset, tmpfile))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Disconnect from the server again:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "invisible(disconnect(server))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "R",
+   "language": "R",
+   "name": "ir"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
A very simple example notebook which currently assumes that there's a dataset `CDK5RAP2-C` in the user's default group, which has an OMERO table (called `Test_Table`) with (Fiji) ROI information attached. It just reads the table, performs a clustering of the ROIs with respect to their size (area) and writes the results back to OMERO as attachments to the dataset.
( see http://web-dev-merge.openmicroscopy.org/webclient/?show=dataset-23601 )

/cc @jburel @pwalczysko 
