### PR TITLE
Install romero.gateway from CRAN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,20 +24,12 @@ RUN conda env update -n r-omero -q -f .setup/environment-r-omero.yml && \
     /opt/conda/envs/r-omero/bin/Rscript -e "IRkernel::installspec(displayname='OMERO R')"
 
 USER root
-RUN mkdir /opt/romero /opt/omero && \
-    fix-permissions /opt/romero /opt/omero
-# R requires these two packages at runtime
-RUN apt-get install -y -q \
-    libxrender1 \
-    libsm6
+RUN mkdir /opt/omero && fix-permissions /opt/omero
+
 USER $NB_UID
 
 # install rOMERO
-ENV _JAVA_OPTIONS="-Xss2560k -Xmx2g"
-ARG ROMERO_VERSION=v0.4.3
-RUN cd /opt/romero && \
-    curl -sf https://raw.githubusercontent.com/ome/rOMERO-gateway/$ROMERO_VERSION/install.R --output install.R && \
-    bash -c "source activate r-omero && Rscript install.R --version=$ROMERO_VERSION --quiet"
+RUN /opt/conda/envs/r-omero/bin/Rscript -e "install.packages('romero.gateway', repos='http://cran.us.r-project.org')"
 
 # OMERO full CLI
 # This currently uses the python2 environment, should we move it to its own?

--- a/docker/environment-r-omero.yml
+++ b/docker/environment-r-omero.yml
@@ -4,22 +4,10 @@ channels:
 - defaults
 dependencies:
 - bioconductor-ebimage=4.13.*
-- maven=3.5.*
 - openjdk=8.0.*
-- r-assertthat=0.2.*
-# https://github.com/ContinuumIO/anaconda-issues/issues/4656
 - r-base=3.4.*
-- r-devtools=1.13.*
-- r-git2r=0.19.*
-- r-httr=1.3.*
+- r-jpeg=0.1_8
+- r-rjava=0.9_8
 - r-irdisplay=0.4.*
 - r-irkernel=0.8.*
-- r-jpeg=0.1_8
-- r-repr=0.13
-- r-rjava=0.9_8
-- r-roxygen2=6.0.*
-- r-testthat=1.0.*
-- r-tidyverse=1.1.*
-- r-xml2=1.1.*
-- r-getpass=0.2.*
 prefix: /opt/conda/envs/r-omero

--- a/docker/environment-r-omero.yml
+++ b/docker/environment-r-omero.yml
@@ -3,11 +3,11 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- bioconductor-ebimage=4.13.*
+- bioconductor-ebimage=4.22.*
 - openjdk=8.0.*
-- r-base=3.4.*
+- r-base=3.5_1
 - r-jpeg=0.1_8
-- r-rjava=0.9_8
-- r-irdisplay=0.4.*
+- r-rjava=0.9_10
+- r-irdisplay=0.5.*
 - r-irkernel=0.8.*
 prefix: /opt/conda/envs/r-omero


### PR DESCRIPTION
Install the romero.gateway package from CRAN instead of using the `install.R` script.

**Test:**
- `docker build -t training-notebooks .`
- `docker run -it  -p 8888:8888 training-notebooks`
-  Start up `idr0021 Segmentation` notebook and execute the second code block where the romero.gateway library is loaded.
