### PR TITLE
Bugfix: Cellprofiler notebook

### DIFF
--- a/CellProfiler/idr0002.ipynb
+++ b/CellProfiler/idr0002.ipynb
@@ -267,7 +267,6 @@
     "table = resources.newTable(repository_id, table_name)\n",
     "table.initialize(cols)\n",
     "table.addData(cols)\n",
-    "table.close()\n",
     "\n",
     "# Link the table to the plate\n",
     "orig_file = table.getOriginalFile()\n",
@@ -275,7 +274,8 @@
     "file_ann.setNs(NSBULKANNOTATIONS)\n",
     "file_ann._obj.file = OriginalFileI(orig_file.id.val, False)\n",
     "file_ann.save()\n",
-    "plate.linkAnnotation(file_ann)"
+    "plate.linkAnnotation(file_ann)\n",
+    "table.close()"
    ]
   },
   {


### PR DESCRIPTION
Just a small fix for an error which showed up in the Freising workshop. After calling `table.close()` the table is not accessible any longer, so `table.getOriginalFile()` throws an Exception. This PR simply moves the `close()` call after the `getOriginalFile()` call.
